### PR TITLE
チェス盤のUIを改善して視認性を向上

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+tmp

--- a/src/components/ChessBoard.tsx
+++ b/src/components/ChessBoard.tsx
@@ -1,10 +1,10 @@
-import type React from 'react';
-import type { Board, Piece, Position } from '../types';
+import type React from 'react'
+import type { Board, Piece, Position } from '../types'
 
 interface ChessBoardProps {
-  board: Board;
-  selectedSquare: Position | null;
-  onSquareClick: (position: Position) => void;
+  board: Board
+  selectedSquare: Position | null
+  onSquareClick: (position: Position) => void
 }
 
 const ChessBoard: React.FC<ChessBoardProps> = ({
@@ -30,24 +30,24 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
         knight: '♞',
         pawn: '♟',
       },
-    };
-    return symbols[piece.color][piece.type];
-  };
+    }
+    return symbols[piece.color][piece.type]
+  }
 
   const isSelected = (row: number, col: number): boolean => {
-    return selectedSquare?.row === row && selectedSquare?.col === col;
-  };
+    return selectedSquare?.row === row && selectedSquare?.col === col
+  }
 
   const getSquareColor = (row: number, col: number): string => {
-    const isLight = (row + col) % 2 === 0;
+    const isLight = (row + col) % 2 === 0
     if (isSelected(row, col)) {
-      return isLight ? 'bg-yellow-300' : 'bg-yellow-600';
+      return isLight ? 'bg-yellow-300' : 'bg-yellow-600'
     }
-    return isLight ? 'bg-amber-100' : 'bg-amber-800';
-  };
+    return isLight ? 'bg-amber-100' : 'bg-amber-800'
+  }
 
   return (
-    <div className="grid grid-cols-8 grid-rows-8 w-96 h-96 border-2 border-gray-800">
+    <div className="grid grid-cols-8 grid-rows-8 w-[600px] h-[600px] border-4 border-gray-900 shadow-xl">
       {board.map((row, rowIndex) =>
         row.map((piece, colIndex) => (
           <div
@@ -57,17 +57,19 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
               ${getSquareColor(rowIndex, colIndex)}
               flex items-center justify-center
               cursor-pointer
-              text-4xl
+              text-6xl
               hover:brightness-110
               aspect-square
+              border border-gray-600
+              transition-all duration-150
             `}
             role="button"
             tabIndex={0}
             onClick={() => onSquareClick({ row: rowIndex, col: colIndex })}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onSquareClick({ row: rowIndex, col: colIndex });
+                e.preventDefault()
+                onSquareClick({ row: rowIndex, col: colIndex })
               }
             }}
           >
@@ -76,7 +78,7 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
         )),
       )}
     </div>
-  );
-};
+  )
+}
 
-export default ChessBoard;
+export default ChessBoard


### PR DESCRIPTION
## Summary
- チェス盤のサイズを384pxから600pxに拡大してより見やすく改善
- 各マス目に境界線を追加してマス目の区切りを明確化
- チェス盤全体の境界線を太くしてシャドウを追加
- 駒のサイズを拡大（text-4xl → text-6xl）して視認性向上
- ホバー時のアニメーション効果を追加してUX改善

## Test plan
- [ ] チェス盤が正しく表示される
- [ ] マス目の境界線が見える
- [ ] 駒が大きく見やすくなっている
- [ ] ホバー効果が動作する
- [ ] ゲームが正常に動作する

🤖 Generated with [Claude Code](https://claude.ai/code)