### PR TITLE
移動候補マスのハイライト機能を実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,14 @@ import ChessBoard from './components/ChessBoard';
 import { useChessGame } from './hooks/useChessGame';
 
 function App() {
-  const { board, currentPlayer, selectedSquare, handleSquareClick, resetGame } =
-    useChessGame();
+  const {
+    board,
+    currentPlayer,
+    selectedSquare,
+    validMoves,
+    handleSquareClick,
+    resetGame,
+  } = useChessGame();
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center justify-center p-4">
@@ -17,6 +23,7 @@ function App() {
       <ChessBoard
         board={board}
         selectedSquare={selectedSquare}
+        validMoves={validMoves}
         onSquareClick={handleSquareClick}
       />
 

--- a/src/components/ChessBoard.tsx
+++ b/src/components/ChessBoard.tsx
@@ -1,15 +1,17 @@
-import type React from 'react'
-import type { Board, Piece, Position } from '../types'
+import type React from 'react';
+import type { Board, Piece, Position } from '../types';
 
 interface ChessBoardProps {
-  board: Board
-  selectedSquare: Position | null
-  onSquareClick: (position: Position) => void
+  board: Board;
+  selectedSquare: Position | null;
+  validMoves: Position[];
+  onSquareClick: (position: Position) => void;
 }
 
 const ChessBoard: React.FC<ChessBoardProps> = ({
   board,
   selectedSquare,
+  validMoves,
   onSquareClick,
 }) => {
   const getPieceSymbol = (piece: Piece): string => {
@@ -30,21 +32,31 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
         knight: '♞',
         pawn: '♟',
       },
-    }
-    return symbols[piece.color][piece.type]
-  }
+    };
+    return symbols[piece.color][piece.type];
+  };
 
   const isSelected = (row: number, col: number): boolean => {
-    return selectedSquare?.row === row && selectedSquare?.col === col
-  }
+    return selectedSquare?.row === row && selectedSquare?.col === col;
+  };
+
+  const isValidMove = (row: number, col: number): boolean => {
+    return validMoves.some((move) => move.row === row && move.col === col);
+  };
 
   const getSquareColor = (row: number, col: number): string => {
-    const isLight = (row + col) % 2 === 0
+    const isLight = (row + col) % 2 === 0;
+
     if (isSelected(row, col)) {
-      return isLight ? 'bg-yellow-300' : 'bg-yellow-500'
+      return isLight ? 'bg-yellow-300' : 'bg-yellow-500';
     }
-    return isLight ? 'bg-stone-200' : 'bg-stone-600'
-  }
+
+    if (isValidMove(row, col)) {
+      return isLight ? 'bg-green-300' : 'bg-green-500';
+    }
+
+    return isLight ? 'bg-stone-200' : 'bg-stone-600';
+  };
 
   return (
     <div className="grid grid-cols-8 grid-rows-8 w-[600px] h-[600px] border-4 border-gray-900 shadow-xl">
@@ -68,8 +80,8 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
             onClick={() => onSquareClick({ row: rowIndex, col: colIndex })}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault()
-                onSquareClick({ row: rowIndex, col: colIndex })
+                e.preventDefault();
+                onSquareClick({ row: rowIndex, col: colIndex });
               }
             }}
           >
@@ -78,7 +90,7 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
         )),
       )}
     </div>
-  )
-}
+  );
+};
 
-export default ChessBoard
+export default ChessBoard;

--- a/src/hooks/useChessGame.ts
+++ b/src/hooks/useChessGame.ts
@@ -2,11 +2,13 @@ import { useState } from 'react';
 import type { Board, Color, Position } from '../types';
 import { createInitialBoard } from '../utils/initialBoard';
 import { isValidMove } from '../utils/moveValidation';
+import { getValidMoves } from '../utils/validMoves';
 
 export const useChessGame = () => {
   const [board, setBoard] = useState<Board>(createInitialBoard());
   const [currentPlayer, setCurrentPlayer] = useState<Color>('white');
   const [selectedSquare, setSelectedSquare] = useState<Position | null>(null);
+  const [validMoves, setValidMoves] = useState<Position[]>([]);
 
   const handleSquareClick = (position: Position) => {
     const { row, col } = position;
@@ -29,10 +31,12 @@ export const useChessGame = () => {
       }
 
       setSelectedSquare(null);
+      setValidMoves([]);
     } else {
       // Select piece
       if (piece && piece.color === currentPlayer) {
         setSelectedSquare(position);
+        setValidMoves(getValidMoves(board, position));
       }
     }
   };
@@ -41,12 +45,14 @@ export const useChessGame = () => {
     setBoard(createInitialBoard());
     setCurrentPlayer('white');
     setSelectedSquare(null);
+    setValidMoves([]);
   };
 
   return {
     board,
     currentPlayer,
     selectedSquare,
+    validMoves,
     handleSquareClick,
     resetGame,
   };

--- a/src/utils/validMoves.ts
+++ b/src/utils/validMoves.ts
@@ -1,0 +1,25 @@
+import type { Board, Position } from '../types';
+import { isValidMove } from './moveValidation';
+
+export const getValidMoves = (
+  board: Board,
+  fromPosition: Position,
+): Position[] => {
+  const validMoves: Position[] = [];
+  const piece = board[fromPosition.row][fromPosition.col];
+
+  if (!piece) return validMoves;
+
+  // 全てのマスをチェックして有効な移動先を見つける
+  for (let row = 0; row < 8; row++) {
+    for (let col = 0; col < 8; col++) {
+      const toPosition = { row, col };
+
+      if (isValidMove(board, fromPosition, toPosition, piece)) {
+        validMoves.push(toPosition);
+      }
+    }
+  }
+
+  return validMoves;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,8 @@ export default {
     'bg-stone-600',
     'bg-yellow-300',
     'bg-yellow-500',
+    'bg-green-300',
+    'bg-green-500',
   ],
   plugins: [],
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
駒を選択したときに移動可能なマスを視覚的にハイライト表示する機能を実装しました。

## 主な変更点
- **`validMoves.ts`**: 移動可能なマスを計算するユーティリティ関数を新規作成
- **`useChessGame.ts`**: 移動候補の状態管理を追加
- **`ChessBoard.tsx`**: 移動候補マスを緑色でハイライト表示する機能を実装
- **`App.tsx`**: validMovesプロパティをChessBoardに渡すよう更新
- **`tailwind.config.js`**: 緑色のクラスをsafelistに追加

## 新機能の詳細
- 駒を選択すると、その駒が移動可能なマスが**緑色**でハイライト表示される
- 選択された駒自体は**黄色**でハイライト表示される（既存機能）
- 移動完了または別の駒を選択すると、ハイライトがリセットされる
- チェスのルールに基づいた正確な移動候補計算

## ユーザビリティの向上
- どのマスに移動できるかが一目でわかるようになり、ゲームの操作性が大幅に向上
- 初心者でも各駒の移動パターンを理解しやすくなる
- 無効な移動を試すことが減り、スムーズなゲームプレイが可能

## Test plan
- [x] 駒選択時に移動候補マスが緑色でハイライト表示される
- [x] 選択された駒が黄色でハイライト表示される
- [x] 移動後にハイライトがリセットされる
- [x] 各駒種（ポーン、ルーク、ビショップ、ナイト、クイーン、キング）の移動候補が正確に表示される
- [x] リンターとタイプチェックが通る
- [x] Tailwind CSSのスタイルが正常に適用される

🤖 Generated with [Claude Code](https://claude.ai/code)